### PR TITLE
Allow package_ensure to specify specific versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #   A hash of config key-value entries for master.cf
 #
 # @param package_ensure
-#   The state the postfix package should be ensured.
+#   The state or version the postfix package should be ensured.
 #
 # @param package_manage
 #   Whether to install the postfix and plugin packages.
@@ -59,7 +59,7 @@ class postfix (
   Enum['installed', 'present', 'latest'] $mailx_ensure,
   Boolean $mailx_manage,
   String $mailx_package,
-  Enum['installed', 'present', 'latest'] $package_ensure,
+  Variant[String,Enum['installed', 'present', 'latest']] $package_ensure,
   Boolean $package_manage,
   String $package_name,
   Hash $plugin,

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -31,6 +31,12 @@ describe 'postfix' do
 
         it { is_expected.not_to contain_service('postfix') }
       end
+
+      context 'with version string' do
+        let(:params) { { package_ensure: '1.2.3-4.el5' } }
+
+        it { is_expected.to contain_package('postfix').with_ensure('1.2.3-4.el5') }
+      end
     end
   end
 end


### PR DESCRIPTION
Update the type for `postfix::package_ensure` to allow any string. Technically, just `String` is sufficient here, because it covers all the Enum values - however for documentation I think it is useful to include the Enum here.